### PR TITLE
MarkDown renderer: fix some bugs / improve generated markup

### DIFF
--- a/src/antsibull_docutils/markdown.py
+++ b/src/antsibull_docutils/markdown.py
@@ -477,7 +477,7 @@ class Translator(nodes.NodeVisitor):  # pylint: disable=too-many-public-methods
                         self.add_main(f"{indent}{line}\n")
                     indent = list_context.next_indent
                 if not self._main:
-                    self.add_main(f"{indent}\\ \n")
+                    self.add_main(f"{indent.rstrip(' ')}\n")
 
         self._context.push_context(ListItemContext())
 

--- a/src/antsibull_docutils/markdown.py
+++ b/src/antsibull_docutils/markdown.py
@@ -582,6 +582,7 @@ class Translator(nodes.NodeVisitor):  # pylint: disable=too-many-public-methods
                     + [f"> {line}\n" if line else ">\n" for line in lines]
                 )
 
+        self._context.top.ensure_double_newline()
         self._context.push_context(NoteContext())
 
     # pylint: disable-next=missing-function-docstring,unused-argument

--- a/src/antsibull_docutils/markdown.py
+++ b/src/antsibull_docutils/markdown.py
@@ -577,7 +577,10 @@ class Translator(nodes.NodeVisitor):  # pylint: disable=too-many-public-methods
                 self.ensure_double_newline()
                 lines = self.get_text().rstrip("\n").splitlines()
                 # See https://github.com/orgs/community/discussions/16925 for the syntax
-                self.replace_main(["> [!NOTE]\n"] + [f"> {line}\n" for line in lines])
+                self.replace_main(
+                    ["> [!NOTE]\n"]
+                    + [f"> {line}\n" if line else ">\n" for line in lines]
+                )
 
         self._context.push_context(NoteContext())
 

--- a/src/antsibull_docutils/markdown.py
+++ b/src/antsibull_docutils/markdown.py
@@ -44,7 +44,7 @@ class GlobalContext:
         """
         if label in self.labels:
             return self.labels[label]
-        fragment = _urllib_quote(label, safe="")
+        fragment = self.register_new_fragment(_urllib_quote(label, safe=""))
         self.labels[label] = fragment
         self.fragments.add(fragment)
         return fragment

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import pytest
 
-from antsibull_docutils.markdown import render_as_markdown
+from antsibull_docutils.markdown import GlobalContext, render_as_markdown
 from antsibull_docutils.utils import get_document_structure
 
 RENDER_AS_MARKDOWN_AND_STRUCTURE_DATA = [
@@ -783,3 +783,43 @@ def test_render_as_markdown(
     print(get_document_structure(input, parser_name=input_parser).output)
     assert result.output == output
     assert result.unsupported_class_names == unsupported_class_names
+
+
+def test_global_context():
+    global_context = GlobalContext()
+    assert global_context.register_new_fragment("foo") == "foo"
+    assert global_context.register_new_fragment("foo") == "foo-1"
+    assert global_context.register_new_fragment("foo") == "foo-2"
+    code = r"""
+====
+Test
+====
+
+Some test.
+
+.. _foo:
+.. _foobar:
+
+Foo
+^^^
+
+This is some text. `Foo`_.
+"""
+    expected = r"""# Test
+
+Some test\.
+
+<a id="foo-3"></a>
+<a id="foobar"></a>
+
+<a id="foo-1-1"></a>
+## Foo
+
+This is some text\. [Foo](\#foo\-3)\."""
+    assert (
+        render_as_markdown(
+            code, global_context=global_context, parser_name="restructuredtext"
+        ).output
+        == expected
+    )
+    assert global_context.register_new_fragment("foo") == "foo-4"

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -88,9 +88,8 @@ An enumeration:
    And some code.
    ```
 1. another one
-1. \ 
+1.
 1. a last one""",
-        # TODO: instead of '- \ ', use '-'
         set(),
     ),
     (
@@ -361,7 +360,7 @@ An enumeration:
    - Another entry
 
      1. Subenum
-     
+
         .. code:: markdown
 
             Some codeblock:
@@ -385,7 +384,7 @@ Some code:
 .. note::
 
   Some note.
-  
+
   This note has two paragraphs.
 
 A sub-sub-title
@@ -443,7 +442,7 @@ A list\:
 
   This is still item 2\.
 - Item 3\.
-- \ 
+-
 - Item 5 after an empty item\.
 
 An enumeration\:

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -477,6 +477,7 @@ def main(argv):
     if argv[1] == 'help':
         print('Help!')
 ```
+
 > [!NOTE]
 > Some note\.
 >
@@ -726,6 +727,18 @@ A block quote:
 .. note::
 
   And another note.
+
+- A list item
+- .. note::
+
+    This is a note.
+    A second line!
+
+    And a second paragraph.
+
+  .. note::
+
+    And another note.
 """,
         "restructuredtext",
         r"""A block quote\:
@@ -734,14 +747,25 @@ A block quote:
 > Another line\.
 >
 > Another paragraph\.
+
 > [!NOTE]
 > This is a note\.
 > A second line\!
 >
 > And a second paragraph\.
+
 > [!NOTE]
-> And another note\.""",
-        # TODO: Expecting a newline before [!NOTE].
+> And another note\.
+
+- A list item
+- > [!NOTE]
+  > This is a note\.
+  > A second line\!
+  >
+  > And a second paragraph\.
+
+  > [!NOTE]
+  > And another note\.""",
         set(),
     ),
 ]

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -203,7 +203,7 @@ A line\.
 > [!NOTE]
 > This is a note\.
 > A second line\!
-> 
+>
 > And a second paragraph\.""",
         set(),
     ),
@@ -479,7 +479,7 @@ def main(argv):
 ```
 > [!NOTE]
 > Some note\.
-> 
+>
 > This note has two paragraphs\.
 
 <a id="a-sub-sub-title"></a>
@@ -737,12 +737,11 @@ A block quote:
 > [!NOTE]
 > This is a note\.
 > A second line\!
-> 
+>
 > And a second paragraph\.
 > [!NOTE]
 > And another note\.""",
         # TODO: Expecting a newline before [!NOTE].
-        # TODO: Also there should not be a trailing space.
         set(),
     ),
 ]


### PR DESCRIPTION
- Avoid trailing space for empty enumeration/itemize items.
- Avoid trailing spaces in notes.
- Make sure there's a newline before a note.
- Avoid duplicate fragments in rendered output.