### PR TITLE
Ensure type of publish_parts()' `whole` output

### DIFF
--- a/changelogs/fragments/6-type.yml
+++ b/changelogs/fragments/6-type.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Ensure that docutils' ``publish_parts()`` ``whole`` output is a text string and not bytes (https://github.com/ansible-community/antsibull-docutils/pull/6)."

--- a/src/antsibull_docutils/markdown.py
+++ b/src/antsibull_docutils/markdown.py
@@ -726,6 +726,7 @@ def render_as_markdown(
         global_context = GlobalContext()
     document_context = DocumentContext(global_context)
     warnings_stream = io.StringIO()
+    # pylint: disable=duplicate-code
     parts = publish_parts(
         source=source,
         source_path=source_path,
@@ -736,6 +737,7 @@ def render_as_markdown(
             warnings_stream=warnings_stream
         ),
     )
+    # pylint: enable=duplicate-code
     whole = parts["whole"]
     return RenderResult(
         whole.decode("utf-8") if isinstance(whole, bytes) else whole,

--- a/src/antsibull_docutils/markdown.py
+++ b/src/antsibull_docutils/markdown.py
@@ -736,8 +736,9 @@ def render_as_markdown(
             warnings_stream=warnings_stream
         ),
     )
+    whole = parts["whole"]
     return RenderResult(
-        parts["whole"],
+        whole.decode("utf-8") if isinstance(whole, bytes) else whole,
         document_context.unknown_node_types,
         warnings_stream.getvalue().splitlines(),
     )

--- a/src/antsibull_docutils/utils.py
+++ b/src/antsibull_docutils/utils.py
@@ -71,7 +71,12 @@ def get_document_structure(
             warnings_stream=warnings_stream
         ),
     )
-    return RenderResult(parts["whole"], set(), warnings_stream.getvalue().splitlines())
+    whole = parts["whole"]
+    return RenderResult(
+        whole.decode("utf-8") if isinstance(whole, bytes) else whole,
+        set(),
+        warnings_stream.getvalue().splitlines(),
+    )
 
 
 def ensure_newline_after_last_content(lines: list[str]) -> None:


### PR DESCRIPTION
Currently the nightly CI fails (https://github.com/ansible-community/antsibull-docutils/actions/runs/12112200054). I'm not sure whether `bytes` is actually possible as a return value for the renderers we use, or whether it's just that the typing says that `bytes` *could* be possible (depending on the renderer).