### PR TITLE
Make sure path-like objects are converted to strings first

### DIFF
--- a/changelogs/fragments/13-path.yml
+++ b/changelogs/fragments/13-path.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Ensure that ``path`` and ``root_prefix`` for ``antsibull_docutils.rst_code_finder.find_code_blocks()`` can actually be path-like objects (https://github.com/ansible-community/antsibull-docutils/pull/13)."

--- a/src/antsibull_docutils/rst_code_finder.py
+++ b/src/antsibull_docutils/rst_code_finder.py
@@ -273,7 +273,7 @@ def _parse_document(
     publisher = Publisher(source_class=StringInput)
     publisher.set_components("standalone", "restructuredtext", "pseudoxml")
     override = {
-        "root_prefix": root_prefix,
+        "root_prefix": str(root_prefix),
         "input_encoding": "utf-8",
         "file_insertion_enabled": False,
         "raw_enabled": False,
@@ -282,7 +282,7 @@ def _parse_document(
         "warning_stream": io.StringIO(),
     }
     publisher.process_programmatic_settings(None, override, None)
-    publisher.set_source(content, path)
+    publisher.set_source(content, str(path))
 
     # Parse the document
     try:


### PR DESCRIPTION
docutils doesn't seem to like `pathlib.Path`, for example.