### PR TITLE
Sign release tags and release commits

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -175,7 +175,9 @@ def bump(session: nox.Session):
             fragment_file,
             external=True,
         )
-        session.run("git", "commit", "-m", f"Prepare {version}.", external=True)
+        session.run(
+            "git", "commit", "-m", f"Prepare {version}.", "--gpg-sign", external=True
+        )
     session.run("antsibull-changelog", "release")
     session.run(
         "git",
@@ -190,7 +192,9 @@ def bump(session: nox.Session):
         external=True,
     )
     install(session, ".")  # Smoke test
-    session.run("git", "commit", "-m", f"Release {version}.", external=True)
+    session.run(
+        "git", "commit", "-m", f"Release {version}.", "--gpg-sign", external=True
+    )
     session.run(
         "git",
         "tag",
@@ -214,7 +218,9 @@ def publish(session: nox.Session):
     session.run("hatch", "publish", *session.posargs)
     session.run("hatch", "version", "post")
     session.run("git", "add", "src/antsibull_docutils/__init__.py", external=True)
-    session.run("git", "commit", "-m", "Post-release version bump.", external=True)
+    session.run(
+        "git", "commit", "-m", "Post-release version bump.", "--gpg-sign", external=True
+    )
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -195,6 +195,7 @@ def bump(session: nox.Session):
         "git",
         "tag",
         "-a",
+        "-s",
         "-m",
         f"antsibull-docutils {version}",
         "--edit",


### PR DESCRIPTION
Make sure that the preparation, release, and post-release commits are signed. When tagging the release commit, also sign it.